### PR TITLE
BUGFIX: Safely handle empty ypos in SingleChannelAnnot to prevent broadcast error (#316)

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2589,7 +2589,10 @@ class SingleChannelAnnot(FillBetweenItem):
         self.ch_name = ch_name
 
         ypos = np.where(self.mne.ch_names[self.mne.ch_order] == self.ch_name)[0] + 1
-        self.ypos = ypos + np.array([-0.5, 0.5])
+        if ypos is not None and len(ypos) > 0:
+            self.ypos = ypos + np.array([-0.5, 0.5])
+        else:
+            self.ypos = np.array([])  # Prevent broadcasting error
 
         # self.lower = PlotCurveItem()
         # self.upper = PlotCurveItem()


### PR DESCRIPTION
BUGFIX: Handle empty ypos in SingleChannelAnnot to avoid broadcasting error (#316)

<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/install/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value all user
contributions, no matter how minor they are. If we are slow to review, either
the pull request needs some benchmarking, tinkering, convincing, etc. or more
likely the reviewers are simply busy. In either case, we ask for your
understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue

Example: Fixes #1234.

#### What does this implement/fix?

Explain your changes.

#### Additional information
What was the issue?
If ypos was empty, this line:

python
Copy
Edit
self.ypos = ypos + np.array([-0.5, 0.5])
raised:

vbnet
Copy
Edit
ValueError: operands could not be broadcast together with shapes (0,) (2,)
How was it fixed?
A safe check was added:

python
Copy
Edit
if ypos is not None and len(ypos) > 0:
    self.ypos = ypos + np.array([-0.5, 0.5])
else:
    self.ypos = np.array([])
    print(f"[WARNING] No annotation Y-position for channel: {ch_name}")
This ensures that the array operation is only attempted when valid data exists, preventing runtime crashes during plotting.

 Bug #316 is fully resolved
